### PR TITLE
Initialize FastAPI backend and React frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,32 @@
-# agentswarm
-Generative AI system to build an agent swarm for task and problem solving
+# Agent Swarm
+
+This repository contains a FastAPI backend and a React frontend. The React app calls the backend `/health` endpoint to verify connectivity.
+
+## Backend
+
+Install dependencies and start the server:
+
+```bash
+cd backend
+pip install -r requirements.txt
+uvicorn app.main:app --reload
+```
+
+This starts FastAPI on `http://localhost:8000` with `/health` returning `{\"status\": \"ok\"}`.
+
+## Frontend
+
+Install dependencies and start the React development server:
+
+```bash
+cd frontend
+npm install
+npm start
+```
+
+The app runs on `http://localhost:3000` and displays the backend status.
+
+## Folder Structure
+
+- `backend/` – FastAPI application
+- `frontend/` – React application

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,0 +1,17 @@
+from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
+
+app = FastAPI()
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+@app.get("/health")
+async def health():
+    return {"status": "ok"}
+

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,2 @@
+fastapi
+uvicorn

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "frontend",
+  "version": "0.1.0",
+  "private": true,
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-scripts": "5.0.1"
+  },
+  "scripts": {
+    "start": "react-scripts start",
+    "build": "react-scripts build",
+    "test": "react-scripts test",
+    "eject": "react-scripts eject"
+  }
+}

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Agent Swarm</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/index.js"></script>
+  </body>
+</html>

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,0 +1,21 @@
+import React, { useEffect, useState } from 'react';
+
+function App() {
+  const [status, setStatus] = useState('');
+
+  useEffect(() => {
+    fetch('http://localhost:8000/health')
+      .then((res) => res.json())
+      .then((data) => setStatus(data.status))
+      .catch((err) => setStatus('error'));
+  }, []);
+
+  return (
+    <div>
+      <h1>Agent Swarm Frontend</h1>
+      <p>Backend status: {status}</p>
+    </div>
+  );
+}
+
+export default App;

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -1,0 +1,6 @@
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import App from './App';
+
+const root = createRoot(document.getElementById('root'));
+root.render(<App />);


### PR DESCRIPTION
## Summary
- scaffold FastAPI backend with `/health` endpoint and CORS
- add basic React app that displays backend health
- document how to run backend and frontend

## Testing
- `python3 -m py_compile backend/app/main.py`
- `npm -v`


------
https://chatgpt.com/codex/tasks/task_e_6873eee84bc48324aef5ba6e00c47a10