### PR TITLE
Add helper scripts and backend tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,16 @@ Both the backend and frontend can be run independently:
 2. **Frontend only**: The React app will show connection errors if the backend is not running
 3. **Full stack**: Start both servers to test the complete application
 
+   ```bash
+   ./scripts/start.sh
+   ```
+
+4. **Run tests**:
+
+   ```bash
+   ./scripts/test.sh
+   ```
+
 ## API Endpoints
 
 ### Health Check

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,3 +1,5 @@
 fastapi==0.104.1
 uvicorn[standard]==0.24.0
 python-multipart==0.0.6
+pytest==7.4.4
+requests==2.31.0

--- a/backend/tests/test_health.py
+++ b/backend/tests/test_health.py
@@ -1,0 +1,9 @@
+from fastapi.testclient import TestClient
+from backend.main import app
+
+client = TestClient(app)
+
+def test_health_check():
+    response = client.get("/health")
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok"}

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+set -e
+
+# Start the FastAPI backend
+(
+  cd "$(dirname "$0")/../backend" && uvicorn main:app --reload
+) &
+BACKEND_PID=$!
+
+# Start the React frontend
+(
+  cd "$(dirname "$0")/../frontend" && npm run dev
+) &
+FRONTEND_PID=$!
+
+trap 'kill $BACKEND_PID $FRONTEND_PID' EXIT
+
+wait $BACKEND_PID $FRONTEND_PID

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -e
+
+cd "$(dirname "$0")/../backend"
+pytest -q


### PR DESCRIPTION
## Summary
- add `start.sh` to launch backend and frontend together
- add `test.sh` to run backend tests
- write a basic pytest check for the health endpoint
- include `pytest` and `requests` in backend requirements
- document helper scripts in README

## Testing
- `pip install -r requirements.txt` *(fails: Cannot connect to proxy)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6873f62496b88324ae3798f7db644678