### PR TITLE
Add agent creation UI and backend

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -1,5 +1,36 @@
-from fastapi import FastAPI
+from fastapi import FastAPI, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
+from pydantic import BaseModel
+import os
+import sqlite3
+
+DB_PATH = os.environ.get("AGENTSWARM_DB", os.path.join(os.path.dirname(__file__), "agents.db"))
+
+conn = sqlite3.connect(DB_PATH, check_same_thread=False)
+conn.row_factory = sqlite3.Row
+conn.execute(
+    """
+    CREATE TABLE IF NOT EXISTS agents (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        name TEXT NOT NULL,
+        agent_type TEXT NOT NULL,
+        description TEXT,
+        mcp_url TEXT,
+        metadata TEXT
+    )
+    """
+)
+conn.commit()
+
+class AgentCreate(BaseModel):
+    name: str
+    agent_type: str
+    description: str | None = None
+    mcp_url: str | None = None
+    metadata: str | None = None
+
+class Agent(AgentCreate):
+    id: int
 
 app = FastAPI(title="AgentSwarm API", version="1.0.0")
 
@@ -16,6 +47,28 @@ app.add_middleware(
 async def health_check():
     """Health check endpoint"""
     return {"status": "ok"}
+
+
+@app.post("/agents", response_model=Agent)
+async def create_agent(agent: AgentCreate):
+    """Create a new agent"""
+    cur = conn.execute(
+        "INSERT INTO agents (name, agent_type, description, mcp_url, metadata) VALUES (?, ?, ?, ?, ?)",
+        (agent.name, agent.agent_type, agent.description, agent.mcp_url, agent.metadata),
+    )
+    conn.commit()
+    agent_id = cur.lastrowid
+    return {"id": agent_id, **agent.model_dump()}
+
+
+@app.get("/agents", response_model=list[Agent])
+async def list_agents():
+    """List all agents"""
+    cur = conn.execute(
+        "SELECT id, name, agent_type, description, mcp_url, metadata FROM agents"
+    )
+    rows = cur.fetchall()
+    return [Agent(**dict(row)) for row in rows]
 
 if __name__ == "__main__":
     import uvicorn

--- a/backend/tests/test_main.py
+++ b/backend/tests/test_main.py
@@ -1,5 +1,8 @@
+import os
 import pytest
 from fastapi.testclient import TestClient
+
+os.environ["AGENTSWARM_DB"] = ":memory:"
 from main import app
 
 client = TestClient(app)
@@ -14,3 +17,26 @@ def test_app_title():
     """Test that the app has the correct title"""
     assert app.title == "AgentSwarm API"
     assert app.version == "1.0.0"
+
+
+def test_create_and_list_agents():
+    """Test creating a new agent and listing agents"""
+    response = client.post(
+        "/agents",
+        json={
+            "name": "TestAgent",
+            "agent_type": "utility",
+            "description": "test agent",
+            "mcp_url": "http://localhost",
+        },
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["id"] == 1
+    assert data["name"] == "TestAgent"
+
+    # fetch list
+    list_resp = client.get("/agents")
+    assert list_resp.status_code == 200
+    agents = list_resp.json()
+    assert any(a["name"] == "TestAgent" for a in agents)

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react'
+import { useState, useEffect, FormEvent } from 'react'
 import reactLogo from './assets/react.svg'
 import viteLogo from '/vite.svg'
 import './App.css'
@@ -7,11 +7,25 @@ interface HealthStatus {
   status: string;
 }
 
+interface Agent {
+  id: number
+  name: string
+  agent_type: string
+  description?: string
+  mcp_url?: string
+}
+
 function App() {
   const [count, setCount] = useState(0)
   const [healthStatus, setHealthStatus] = useState<HealthStatus | null>(null)
   const [healthError, setHealthError] = useState<string | null>(null)
   const [isLoading, setIsLoading] = useState(false)
+  const [agents, setAgents] = useState<Agent[]>([])
+  const [name, setName] = useState('')
+  const [agentType, setAgentType] = useState('utility')
+  const [description, setDescription] = useState('')
+  const [mcpUrl, setMcpUrl] = useState('')
+  const [formMessage, setFormMessage] = useState<string | null>(null)
 
   const checkBackendHealth = async () => {
     setIsLoading(true)
@@ -30,8 +44,42 @@ function App() {
     }
   }
 
+  const fetchAgents = async () => {
+    const resp = await fetch('http://localhost:8000/agents')
+    if (resp.ok) {
+      const data: Agent[] = await resp.json()
+      setAgents(data)
+    }
+  }
+
+  const handleCreateAgent = async (e: FormEvent) => {
+    e.preventDefault()
+    setFormMessage(null)
+    const resp = await fetch('http://localhost:8000/agents', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        name,
+        agent_type: agentType,
+        description,
+        mcp_url: mcpUrl,
+      }),
+    })
+    if (resp.ok) {
+      setName('')
+      setAgentType('utility')
+      setDescription('')
+      setMcpUrl('')
+      setFormMessage('Agent created!')
+      fetchAgents()
+    } else {
+      setFormMessage('Failed to create agent')
+    }
+  }
+
   useEffect(() => {
     checkBackendHealth()
+    fetchAgents()
   }, [])
 
   return (
@@ -63,6 +111,51 @@ function App() {
             ❌ Error: {healthError}
           </div>
         )}
+      </div>
+
+      <div className="card" style={{ marginTop: '20px' }}>
+        <h2>Create Agent</h2>
+        <form onSubmit={handleCreateAgent} data-testid="agent-form">
+          <div>
+            <label>
+              Agent Name
+              <input value={name} onChange={e => setName(e.target.value)} />
+            </label>
+          </div>
+          <div>
+            <label>
+              Agent Type
+              <select value={agentType} onChange={e => setAgentType(e.target.value)}>
+                <option value="utility">utility</option>
+                <option value="task">task</option>
+                <option value="orchestration">orchestration</option>
+              </select>
+            </label>
+          </div>
+          <div>
+            <label>
+              Description
+              <input value={description} onChange={e => setDescription(e.target.value)} />
+            </label>
+          </div>
+          <div>
+            <label>
+              MCP URL
+              <input value={mcpUrl} onChange={e => setMcpUrl(e.target.value)} />
+            </label>
+          </div>
+          <button type="submit">Create</button>
+        </form>
+        {formMessage && <p>{formMessage}</p>}
+      </div>
+
+      <div className="card" style={{ marginTop: '20px' }}>
+        <h2>Agents</h2>
+        <ul>
+          {agents.map(a => (
+            <li key={a.id}>{a.name} - {a.agent_type}</li>
+          ))}
+        </ul>
       </div>
 
       <div className="card">

--- a/frontend/src/test/App.test.tsx
+++ b/frontend/src/test/App.test.tsx
@@ -40,4 +40,11 @@ describe('App', () => {
     render(<App />)
     expect(screen.getByRole('button', { name: /count is 0/i })).toBeInTheDocument()
   })
+
+  it('renders agent creation form', () => {
+    vi.mocked(globalThis.fetch).mockRejectedValue(new Error('Network error'))
+    render(<App />)
+    expect(screen.getByText('Create Agent')).toBeInTheDocument()
+    expect(screen.getByTestId('agent-form')).toBeInTheDocument()
+  })
 })


### PR DESCRIPTION
## Summary
- implement SQLite database with Agent model and endpoints
- extend FastAPI to create and list agents
- add React form to create agents and list them
- update tests for backend and frontend

## Testing
- `python -m pytest backend/tests/ --tb=short` *(fails: ModuleNotFoundError: No module named 'fastapi')*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68740ffcc53c8324a1b7cee8c5ca19a3