### PR TITLE
feat: Create New Agent from the UI

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,23 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Python: Current File",
+            "type": "debugpy",
+            "request": "launch",
+            "program": "${file}",
+            "python": "${workspaceFolder}/.venv/bin/python",
+            "console": "integratedTerminal",
+            "cwd": "${workspaceFolder}"
+        },
+        {
+            "name": "Python: FastAPI Backend",
+            "type": "debugpy",
+            "request": "launch",
+            "program": "${workspaceFolder}/backend/main.py",
+            "python": "${workspaceFolder}/.venv/bin/python",
+            "console": "integratedTerminal",
+            "cwd": "${workspaceFolder}/backend"
+        }
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,14 @@
+{
+    "python.defaultInterpreterPath": "${workspaceFolder}/.venv/bin/python",
+    "python.terminal.activateEnvironment": true,
+    "python.terminal.activateEnvInCurrentTerminal": true,
+    "python.envFile": "${workspaceFolder}/.env",
+    "terminal.integrated.env.osx": {
+        "VIRTUAL_ENV": "${workspaceFolder}/.venv",
+        "PATH": "${workspaceFolder}/.venv/bin:${env:PATH}"
+    },
+    "terminal.integrated.env.linux": {
+        "VIRTUAL_ENV": "${workspaceFolder}/.venv",
+        "PATH": "${workspaceFolder}/.venv/bin:${env:PATH}"
+    }
+}

--- a/agentswarm.code-workspace
+++ b/agentswarm.code-workspace
@@ -1,0 +1,15 @@
+{
+    "folders": [
+        {
+            "path": "."
+        }
+    ],
+    "settings": {
+        "python.pythonPath": ".venv/bin/python",
+        "python.defaultInterpreterPath": ".venv/bin/python",
+        "python.venvPath": ".",
+        "python.venvFolders": [".venv"],
+        "python.terminal.activateEnvironment": true,
+        "python.terminal.activateEnvInCurrentTerminal": true
+    }
+}

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,7 +1,12 @@
-from fastapi import FastAPI
+from fastapi import FastAPI, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
+from typing import List
+from .models import Agent
 
 app = FastAPI(title="AgentSwarm API", version="1.0.0")
+
+# In-memory database
+agents_db: List[Agent] = []
 
 # Configure CORS
 app.add_middleware(
@@ -11,6 +16,17 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
+
+@app.post("/agents", response_model=Agent, status_code=201)
+async def create_agent(agent: Agent):
+    """Creates a new agent."""
+    agents_db.append(agent)
+    return agent
+
+@app.get("/agents", response_model=List[Agent])
+async def get_agents():
+    """Returns a list of all agents."""
+    return agents_db
 
 @app.get("/health")
 async def health_check():

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,7 +1,7 @@
 from fastapi import FastAPI, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
 from typing import List
-from .models import Agent
+from models import Agent
 
 app = FastAPI(title="AgentSwarm API", version="1.0.0")
 

--- a/backend/models.py
+++ b/backend/models.py
@@ -1,0 +1,14 @@
+from pydantic import BaseModel, Field
+from typing import Optional
+
+class McpConnection(BaseModel):
+    """MCP connection information."""
+    endpoint: str = Field(..., description="The endpoint URL of the MCP.")
+    metadata: Optional[dict] = Field(None, description="Metadata for the MCP connection.")
+
+class Agent(BaseModel):
+    """Represents an agent in the system."""
+    name: str = Field(..., description="The name of the agent.")
+    type: str = Field(..., description="The type of the agent (e.g., utility, task, orchestration).")
+    description: str = Field(..., description="A description of the agent's purpose.")
+    mcp_connection: McpConnection = Field(..., description="MCP connection information.")

--- a/backend/tests/test_main.py
+++ b/backend/tests/test_main.py
@@ -1,5 +1,11 @@
 import pytest
+import sys
+import os
 from fastapi.testclient import TestClient
+
+# Add backend directory to path so we can import main
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
 from main import app
 
 client = TestClient(app)

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,84 +1,58 @@
-import { useState, useEffect } from 'react'
-import reactLogo from './assets/react.svg'
-import viteLogo from '/vite.svg'
-import './App.css'
+import { useState, useEffect } from 'react';
+import AgentForm from './components/AgentForm';
+import './App.css';
 
-interface HealthStatus {
-  status: string;
+interface Agent {
+  name: string;
+  type: string;
+  description: string;
+  mcp_connection: {
+    endpoint: string;
+    metadata?: object;
+  };
 }
 
 function App() {
-  const [count, setCount] = useState(0)
-  const [healthStatus, setHealthStatus] = useState<HealthStatus | null>(null)
-  const [healthError, setHealthError] = useState<string | null>(null)
-  const [isLoading, setIsLoading] = useState(false)
+  const [agents, setAgents] = useState<Agent[]>([]);
 
-  const checkBackendHealth = async () => {
-    setIsLoading(true)
-    setHealthError(null)
+  const fetchAgents = async () => {
     try {
-      const response = await fetch('http://localhost:8000/health')
-      if (!response.ok) {
-        throw new Error(`HTTP error! status: ${response.status}`)
+      const response = await fetch('http://localhost:8000/agents');
+      if (response.ok) {
+        const data = await response.json();
+        setAgents(data);
       }
-      const data: HealthStatus = await response.json()
-      setHealthStatus(data)
     } catch (error) {
-      setHealthError(error instanceof Error ? error.message : 'Failed to connect to backend')
-    } finally {
-      setIsLoading(false)
+      console.error('Error fetching agents:', error);
     }
-  }
+  };
 
   useEffect(() => {
-    checkBackendHealth()
-  }, [])
+    fetchAgents();
+  }, []);
 
   return (
-    <>
-      <div>
-        <a href="https://vite.dev" target="_blank">
-          <img src={viteLogo} className="logo" alt="Vite logo" />
-        </a>
-        <a href="https://react.dev" target="_blank">
-          <img src={reactLogo} className="logo react" alt="React logo" />
-        </a>
-      </div>
-      <h1>AgentSwarm - Frontend</h1>
-      
-      <div className="card">
-        <h2>Backend Health Status</h2>
-        <button onClick={checkBackendHealth} disabled={isLoading}>
-          {isLoading ? 'Checking...' : 'Check Backend Health'}
-        </button>
-        
-        {healthStatus && (
-          <div style={{ marginTop: '10px', padding: '10px', backgroundColor: '#d4edda', border: '1px solid #c3e6cb', borderRadius: '4px' }}>
-            ✅ Backend Status: <strong>{healthStatus.status}</strong>
-          </div>
-        )}
-        
-        {healthError && (
-          <div style={{ marginTop: '10px', padding: '10px', backgroundColor: '#f8d7da', border: '1px solid #f5c6cb', borderRadius: '4px' }}>
-            ❌ Error: {healthError}
-          </div>
+    <div className="App">
+      <h1>AgentSwarm</h1>
+      <AgentForm onAgentCreated={fetchAgents} />
+      <div className="agents-list">
+        <h2>Available Agents</h2>
+        {agents.length === 0 ? (
+          <p>No agents created yet.</p>
+        ) : (
+          <ul>
+            {agents.map((agent, index) => (
+              <li key={index}>
+                <strong>{agent.name}</strong> ({agent.type}) - {agent.description}
+                <br />
+                <small>MCP Endpoint: {agent.mcp_connection.endpoint}</small>
+              </li>
+            ))}
+          </ul>
         )}
       </div>
-
-      <div className="card">
-        <button onClick={() => setCount((count) => count + 1)}>
-          count is {count}
-        </button>
-        <p>
-          Edit <code>src/App.tsx</code> and save to test HMR
-        </p>
-      </div>
-      
-      <p className="read-the-docs">
-        Click on the Vite and React logos to learn more
-      </p>
-    </>
-  )
+    </div>
+  );
 }
 
-export default App
+export default App;

--- a/frontend/src/components/AgentForm.tsx
+++ b/frontend/src/components/AgentForm.tsx
@@ -1,0 +1,74 @@
+import React, { useState } from 'react';
+
+interface AgentFormProps {
+  onAgentCreated: () => void;
+}
+
+const AgentForm: React.FC<AgentFormProps> = ({ onAgentCreated }) => {
+  const [name, setName] = useState('');
+  const [type, setType] = useState('');
+  const [description, setDescription] = useState('');
+  const [endpoint, setEndpoint] = useState('');
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const agentData = {
+      name,
+      type,
+      description,
+      mcp_connection: {
+        endpoint,
+      },
+    };
+
+    try {
+      const response = await fetch('http://localhost:8000/agents', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(agentData),
+      });
+
+      if (response.ok) {
+        // Reset form
+        setName('');
+        setType('');
+        setDescription('');
+        setEndpoint('');
+        onAgentCreated();
+        alert('Agent created successfully!');
+      } else {
+        alert('Failed to create agent.');
+      }
+    } catch (error) {
+      console.error('Error creating agent:', error);
+      alert('Error creating agent.');
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="agent-form">
+      <h2>Create New Agent</h2>
+      <div className="form-group">
+        <label>Name:</label>
+        <input type="text" value={name} onChange={(e) => setName(e.target.value)} required />
+      </div>
+      <div className="form-group">
+        <label>Type:</label>
+        <input type="text" value={type} onChange={(e) => setType(e.target.value)} required />
+      </div>
+      <div className="form-group">
+        <label>Description:</label>
+        <textarea value={description} onChange={(e) => setDescription(e.target.value)} required />
+      </div>
+      <div className="form-group">
+        <label>MCP Endpoint:</label>
+        <input type="text" value={endpoint} onChange={(e) => setEndpoint(e.target.value)} required />
+      </div>
+      <button type="submit">Create Agent</button>
+    </form>
+  );
+};
+
+export default AgentForm;

--- a/frontend/src/test/App.test.tsx
+++ b/frontend/src/test/App.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from '@testing-library/react'
+import { render, screen, act } from '@testing-library/react'
 import { describe, it, expect, beforeEach, vi } from 'vitest'
 import App from '../App'
 
@@ -11,33 +11,41 @@ describe('App', () => {
     vi.resetAllMocks()
   })
 
-  it('renders without crashing', () => {
+  it('renders without crashing', async () => {
     // Mock a failing fetch to avoid loading state
     vi.mocked(globalThis.fetch).mockRejectedValue(new Error('Network error'))
-    render(<App />)
-    expect(screen.getByText('AgentSwarm - Frontend')).toBeInTheDocument()
+    
+    await act(async () => {
+      render(<App />)
+    })
+    
+    expect(screen.getByText('AgentSwarm')).toBeInTheDocument()
   })
 
-  it('displays health check section', async () => {
-    // Mock a successful fetch response
+  it('displays agent creation form', async () => {
+    // Mock a successful fetch response for agents
     vi.mocked(globalThis.fetch).mockResolvedValue({
       ok: true,
-      json: async () => ({ status: 'ok' })
+      json: async () => ([])
     } as Response)
 
-    render(<App />)
-    expect(screen.getByText('Backend Health Status')).toBeInTheDocument()
-    
-    // Wait for the loading to complete and button text to update
-    await waitFor(() => {
-      expect(screen.getByRole('button', { name: /check backend health/i })).toBeInTheDocument()
+    await act(async () => {
+      render(<App />)
     })
+    
+    expect(screen.getByText('Create New Agent')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /create agent/i })).toBeInTheDocument()
   })
 
-  it('displays counter functionality', () => {
+  it('displays agents list section', async () => {
     // Mock a failing fetch to avoid loading state
     vi.mocked(globalThis.fetch).mockRejectedValue(new Error('Network error'))
-    render(<App />)
-    expect(screen.getByRole('button', { name: /count is 0/i })).toBeInTheDocument()
+    
+    await act(async () => {
+      render(<App />)
+    })
+    
+    expect(screen.getByText('Available Agents')).toBeInTheDocument()
+    expect(screen.getByText('No agents created yet.')).toBeInTheDocument()
   })
 })

--- a/scripts/activate-env.sh
+++ b/scripts/activate-env.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# Script to activate the correct virtual environment for AgentSwarm
+
+# Change to the project root directory
+cd "$(dirname "$0")"
+
+# Check if .venv exists
+if [ ! -d ".venv" ]; then
+    echo "❌ Error: .venv virtual environment not found."
+    echo "Please run: python3 -m venv .venv && source .venv/bin/activate && pip install -r backend/requirements.txt"
+    exit 1
+fi
+
+# Activate the virtual environment
+echo "🐍 Activating .venv virtual environment..."
+source .venv/bin/activate
+
+# Verify activation
+if [ "$VIRTUAL_ENV" = "$(pwd)/.venv" ]; then
+    echo "✅ Successfully activated .venv environment"
+    echo "Python path: $(which python)"
+else
+    echo "❌ Failed to activate .venv environment"
+    exit 1
+fi
+
+# Keep the shell open with the activated environment
+exec "$SHELL"


### PR DESCRIPTION
This commit implements the ability for you to create a new agent through the web interface.

The changes include:
- A new React form that allows you to input agent details such as name, type, description, and MCP connection info.
- A new backend endpoint that receives the form data and stores the new agent in a database.
- A success message is shown upon successful creation of an agent.
- The list of agents is updated to include the newly created agent.